### PR TITLE
Set initial values on hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,10 @@ const [newProp, setNewProp] = useStore.newProp("Initial value of newProp")
 const [anotherProp, setAnotherProp] = useStore.anotherProp()
 // ...
 setAnotherProp("Initial value of anotherProp")
+setNewProp("Next value of newProp")
 ```
 
-The **argument only works when the value is undefined**. For example this is not going to work because `username` is already defined inside the `createStore`:
+The hook argument works to define the initial value. It doesn't work when the initial value is already defined in `createStore` or `Provider`:
 
 ```js
 const { Provider } = createStore({ username: "Aral" });
@@ -161,6 +162,8 @@ const { Provider } = createStore({ username: "Aral" });
 const [username, setUsername] = useStore.username("Another name")
 console.log(username) // -> Aral
 ```
+
+In this case, if you want to update the value you should use the `setUsername` method.
 
 #### 3. Using all the store with `useStore` directly *(not recommended)*
 

--- a/package/index.js
+++ b/package/index.js
@@ -65,7 +65,7 @@ export default function createStore(defaultStore = {}, defaultCallbacks = {}) {
     discard: new Set(["prototype", "isReactComponent"]),
     get(_, path) {
       if (!this.discard.has(path)) this.path.push(path);
-      return new Proxy(() => { }, validator);
+      return new Proxy(() => {}, validator);
     },
     apply(t, _, args) {
       const path = this.path.slice();
@@ -81,22 +81,25 @@ export default function createStore(defaultStore = {}, defaultCallbacks = {}) {
       // const [cartQuantity, setCartQuantity] = useStore.cart.quantity()
       // const [newProp, setNewProp, resetNewProp] = useStore.newProp()
       const prop = path.join(".");
-      const update = updateField(prop)
-      let value = getField(allStore, prop)
-      let initializeValue = args[0] !== undefined && value === undefined
+      const update = updateField(prop);
+      let value = getField(allStore, prop);
 
-      // Set initial value
+      let initializeValue =
+        args[0] !== undefined &&
+        value === undefined &&
+        getField(initialStore, prop) === undefined;
+
       if (initializeValue) {
         value = args[0];
         initialStore = setField(initialStore, path, value);
       }
-      useEffect(() => initializeValue && update(value), [])
+      useEffect(() => initializeValue && update(value), []);
       useSubscription(`store.${prop}`);
 
       return [value, update, resetField(prop)];
     },
   };
-  const useStore = new Proxy(() => { }, validator);
+  const useStore = new Proxy(() => {}, validator);
 
   /**
    *

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -66,7 +66,7 @@ describe("Examples", () => {
   });
 
   test("should work with a counter: as a new value (not defined on the store)", async () => {
-    const { useStore, Provider } = createStore({ anotherValue: '' });
+    const { useStore, Provider } = createStore({ anotherValue: "" });
 
     function Counter() {
       const [count, setCount, resetCount] = useStore.count();
@@ -81,8 +81,10 @@ describe("Examples", () => {
     }
 
     function DisplayCounter() {
-      const [anotherValue] = useStore.anotherValue('Should not be overwritted (only for initial values)');
-      const [count] = useStore.count(0); // default value
+      const [anotherValue] = useStore.anotherValue(
+        "Should not be overwritted (only for initial values)"
+      );
+      const [count] = useStore.count(0); // initial value
       return (
         <>
           <p data-testid="number">{count}</p>


### PR DESCRIPTION
Allowing to define the initial value for new store properties directly in the hook:

```js
const { useStore, Provider } = createStore()
// ...

// Inside the component:
const [price, setPrice] = useStore.cart.price(0) // { cart: { price: 0 } } as initial store
const [cartItems, setCartItems] = useStore.cart.items([]) // [] as initial value of cart.items. 

// Initial store now is: { cart: { price: 0, items: [] } } 
// Similar than:
// const { useStore, Provider } = createStore({ cart: { items: [], price: 0 }})
```