### PR TITLE
Convert onAfterUpdate to be more easy, tiny and powerful

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     'require-jsdoc': 0,
     'react/prop-types': 0,
     'prefer-const': 0,
+    'linebreak-style': ['error', process.platform === 'win32' ? 'windows' : 'unix'],
     'max-len': [
       'error',
       {'code': 80, 'ignoreStrings': true},

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ const initialStore = {
   cart: { price: 0, items: [] },
 };
 
-function onAfterUpdate({ path, value, prevValue })
+function onAfterUpdate({ store, prevStore })
   console.log("This callback is executed after an update");
 }
 
@@ -213,10 +213,10 @@ function Example() {
 
 _Input:_
 
-| name                  | type       | description                                                                                                                                                                                                                                    | example                                                                                                                                                                                                                    |
-| --------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Initial value         | `any`      | This parameter is **not mandatory**. It only makes sense for new store properties that have not been defined before within the `createStore`. If the value has already been initialized inside the `createStore` this parameter has no effect. | `const [price, setPrice] = useStore.cart.price(0)`                                                                                                                                                                         |
-| event after an update | `function` | This parameter is **not mandatory**. Adds an event that is executed every time there is a change inside the indicated store portion.                                                                                                           | `const [price, setPrice] = useStore.cart.price(0, onAfterUpdate)`<div><small>And the function:</small></div><div>`function onAfterUpdate({ path, value, prevValue }){ console.log({ prevValue, value }) }`</div> |
+| name                  | type       | description                                                                                                                                                                                                                                    | example                                                                                                                                                                                                    |
+| --------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Initial value         | `any`      | This parameter is **not mandatory**. It only makes sense for new store properties that have not been defined before within the `createStore`. If the value has already been initialized inside the `createStore` this parameter has no effect. | `const [price, setPrice] = useStore.cart.price(0)`                                                                                                                                                         |
+| event after an update | `function` | This parameter is **not mandatory**. Adds an event that is executed every time there is a change inside the indicated store portion.                                                                                                           | `const [price, setPrice] = useStore.cart.price(0, onAfterUpdate)`<div><small>And the function:</small></div><div>`function onAfterUpdate({ store, prevStore }){ console.log({ store, prevStore }) }`</div> |
 
 _Output:_
 
@@ -236,25 +236,21 @@ It works exactly like `useStore` but with **some differences**:
 - It's **not possible to register events** that are executed after a change.
 
   ```js
-  getStore.cart.price(0, onAfterPriceChange) // ❌
+  getStore.cart.price(0, onAfterPriceChange); // ❌
 
-  function onAfterPriceChange({ path, value, prevValue }) {
-    const [,setErrorMsg] = getStore.errorMsg()
-    setErrorMsg(value > 99 ? 'price should be lower than $99')
+  function onAfterPriceChange({ store, prevStore }) {
+    // ...
   }
   ```
 
   - If the intention is to register events that last forever, it has to be done within the `createStore`:
 
   ```js
-   const { getStore } = createStore(initialStore, onAfterUpdate) // ✅
+  const { getStore } = createStore(initialStore, onAfterUpdate); // ✅
 
-   function onAfterUpdate({ path, value, prevValue }) {
-     if(path === 'cart.price') {
-       const [,setErrorMsg] = getStore.errorMsg()
-       setErrorMsg(value > 99 ? 'price should be lower than $99')
-     }
-   }
+  function onAfterUpdate({ store, prevStore }) {
+    // ..
+  }
   ```
 
 Very useful to use it:
@@ -358,18 +354,21 @@ There are 2 ways to register:
 - **Permanent** events: Inside `createStore`. This event will always be executed for each change made within the store.
 
   ```js
-  export const { useStore, getStore } = createStore(initialStore, onAfterUpdate);
+  export const { useStore, getStore } = createStore(
+    initialStore,
+    onAfterUpdate
+  );
 
-  function onAfterUpdate({ path, prevValue, value }) {
-    if (path !== "count") return;
-
-    const [, setCount] = getStore.count();
-    const [errorMsg, setErrorMsg] = getStore.errorMsg();
-
-    if (value > 99) {
-      setCount(prevValue);
+  function onAfterUpdate({ store, prevStore }) {
+    // Add an error msg
+    if (store.count > 99 && !store.errorMsg) {
+      const [, setErrorMsg] = getStore.errorMsg();
       setErrorMsg("The count value should be lower than 100");
-    } else if (errorMsg) {
+      return;
+    }
+    // Remove error msg
+    if (store.count >= 99 && store.errorMsg) {
+      const [, setErrorMsg] = getStore.errorMsg();
       setErrorMsg();
     }
   }
@@ -382,14 +381,15 @@ There are 2 ways to register:
     const [count, setCount] = useStore.count(0, onAfterUpdate);
     const [errorMsg, setErrorMsg] = useStore.errorMsg();
 
-    // The event lasts as long as this component lives, but
-    // it's also executed if the "count" property is updated
-    // elsewhere.
-    function onAfterUpdate({ value, prevValue }) {
-      if (value > 99) {
-        setCount(prevValue);
+    // The event lasts as long as this component lives
+    function onAfterUpdate({ store, prevStore }) {
+      // Add an error msg
+      if (store.count > 99 && !store.errorMsg) {
         setErrorMsg("The count value should be lower than 100");
-      } else if (errorMsg) {
+        return;
+      }
+      // Remove error msg
+      if (store.count >= 99 && store.errorMsg) {
         setErrorMsg();
       }
     }
@@ -570,16 +570,15 @@ export const { useStore, getStore } = createStore(
   onAfterUpdate
 );
 
-function onAfterUpdate({ path }) {
-  if (path === "cart" || path.startsWith("cart.")) updateCalculatedCartProps();
-}
-
-// Price always will be items.length * 3
-function updateCalculatedCartProps() {
-  const [items] = getStore.cart.items();
-  const [price, setPrice] = getStore.cart.price();
+function onAfterUpdate({ store }) {
+  const { items, price } = store.cart;
   const calculatedPrice = items.length * 3;
-  if (price !== calculatedPrice) setPrice(calculatedPrice);
+
+  // Price always will be items.length * 3
+  if (price !== calculatedPrice) {
+    const [, setPrice] = getStore.cart.price();
+    setPrice(calculatedPrice);
+  }
 }
 ```
 

--- a/package/index.js
+++ b/package/index.js
@@ -126,9 +126,9 @@ export default function createStore(defaultStore = {}, callback) {
    */
   function updateField(path = '') {
     let fieldPath = Array.isArray(path) ? path : path.split(DOT);
-    let prevStore = allStore;
 
     return (newValue) => {
+      let prevStore = allStore;
       let value = newValue;
 
       if (typeof newValue === 'function') {

--- a/package/index.js
+++ b/package/index.js
@@ -110,10 +110,10 @@ export default function createStore(defaultStore = {}, callback) {
 
     useEffect(() => {
       subscription._subscribe(path, forceRender);
-      subscription._subscribe(path, callback);
+      subscription._subscribe(DOT, callback);
       return () => {
         subscription._unsubscribe(path, forceRender);
-        subscription._unsubscribe(path, callback);
+        subscription._unsubscribe(DOT, callback);
       };
     }, []);
   }
@@ -126,7 +126,7 @@ export default function createStore(defaultStore = {}, callback) {
    */
   function updateField(path = '') {
     let fieldPath = Array.isArray(path) ? path : path.split(DOT);
-    let prevValue = getField(allStore, fieldPath);
+    let prevStore = allStore;
 
     return (newValue) => {
       let value = newValue;
@@ -143,10 +143,8 @@ export default function createStore(defaultStore = {}, callback) {
 
       // Notifying to all subscribers
       subscription._notify(DOT+path, {
-        path: fieldPath.join(DOT),
-        value,
-        prevValue,
-        getStore,
+        prevStore,
+        store: allStore,
       });
     };
   }
@@ -200,10 +198,10 @@ function createSubscription() {
       if (!listeners[path]) listeners[path] = new Set();
       listeners[path].add(listener);
     },
-    _notify(path, param) {
-      Object.keys(listeners).forEach((listenersKey) => {
-        if (path.startsWith(listenersKey) || listenersKey.startsWith(path)) {
-          listeners[listenersKey].forEach((listener) => listener(param));
+    _notify(path, params) {
+      Object.keys(listeners).forEach((listenerKey) => {
+        if (path.startsWith(listenerKey) || listenerKey.startsWith(path)) {
+          listeners[listenerKey].forEach((listener) => listener(params));
         }
       });
     },

--- a/tests/onAfterUpdate.test.js
+++ b/tests/onAfterUpdate.test.js
@@ -38,6 +38,8 @@ describe('onAfterUpdate callback', () => {
     act(() => getStore.mount()[1](false));
     expect(callback).toHaveBeenCalledTimes(3);
 
+    // Updating twice to confirm that updates don't call the callback when the
+    // component with the useStore is unmounted
     act(() => update({}));
     act(() => update({}));
     expect(callback).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
It's another breaking change. This one **improves** the three things **(tiny, easy, and powerful)** of the `onAfterUpdate` event.

Instead of: `{ path, value, prevValue, getStore }` ❌

Now it's returning: `{ store, prevStore }` ✅

## WHY?

- **`path`, `value` and `prevValue` problem**: `path` was necessary to know what means the `value` and `prevValue`. This meant that inside you had to have a lot of logic to know if it was the `cart`, `cart.price` or the whole store, and it was very complicated if you wanted to know the previous value of the `price` because you didn't know whether to look at `prevValue.price` (because it was the `cart`) or `prevValue` as `cart.price`. **Now you can just do `store.cart.price` and `prevStore.cart.price`**. It simplifies a lot.
- **`getStore`**:  It was introduced in case you wanted to use it inside the `createStore`. But it is redundant because you can already do the following:
     ```js
      export const { useStore, getStore } = createStore(
        {
          cart: {
            price: 0,
            items: [],
          },
        },
        calculatePriceFromItems
      );
      
      function calculatePriceFromItems({ store }) {
        const { items, price } = store.cart;
        const calculatedPrice = items.length * 3;
      
        if (price !== calculatedPrice) {
          // Using getStore declared on createStore
          const [, setPrice] = getStore.cart.price(); 
          setPrice(calculatedPrice);
        }
      }
     ```